### PR TITLE
Display the coverage only for main project targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ xcov -w LystSDK.xcworkspace -s LystSDK -o xcov_output
 * `--json_report`: Enables the creation of a json report (optional).
 * `--markdown_report`: Enables the creation of a markdown report (optional).
 * `--skip_slack`: Add this flag to avoid publishing results on Slack (optional).
+* `--only_project_targets`: Display the coverage only for main project targets (e.g. skip Pods targets).
 
 _**Note:** All paths you provide should be absolute and unescaped_
 

--- a/lib/xcov.rb
+++ b/lib/xcov.rb
@@ -11,6 +11,7 @@ require 'xcov/model/report'
 require 'xcov/model/target'
 require 'xcov/model/source'
 require 'xcov/model/function'
+require 'xcov/project_extensions'
 require 'fastlane_core'
 
 module Xcov

--- a/lib/xcov/model/report.rb
+++ b/lib/xcov/model/report.rb
@@ -68,6 +68,15 @@ module Xcov
       filtered_targets = filtered_targets.select { |target| !target["name"].include?(".xctest") } if !Xcov.config[:include_test_targets]
       filtered_targets = filtered_targets.select { |target| !self.excluded_targets.include?(target["name"])}
 
+      supported_targets = Xcov.project.targets
+      if Xcov.config[:only_project_targets] && !supported_targets.empty?
+        filtered_targets = filtered_targets.select do |target|
+          name = target["name"]
+          name.slice! File.extname(name) # remove target extensions
+          supported_targets.include?(name)
+        end
+      end
+
       filtered_targets
     end
 

--- a/lib/xcov/options.rb
+++ b/lib/xcov/options.rb
@@ -98,8 +98,14 @@ module Xcov
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :exclude_targets,
                                      optional: true,
-                                     description: "Comma separated list of targets to exclude from coverage report")
+                                     description: "Comma separated list of targets to exclude from coverage report"),
+        FastlaneCore::ConfigItem.new(key: :only_project_targets,
+                                     description: "Display the coverage only for main project targets (e.g. skip Pods targets)",
+                                     is_string: false,
+                                     default_value: false)
+
       ]
+
     end
 
   end

--- a/lib/xcov/project_extensions.rb
+++ b/lib/xcov/project_extensions.rb
@@ -1,0 +1,33 @@
+require "fastlane_core"
+require "xcodeproj"
+
+module FastlaneCore
+  class Project
+
+    # Returns project targets
+    def targets
+      project_path = get_project_path
+      return [] if project_path.nil?
+
+      proj = Xcodeproj::Project.open(project_path)
+      
+      proj.targets.map do |target|
+       target.name
+     end
+    end
+
+    private
+    
+    def get_project_path
+      # Given the workspace and scheme, we can compute project path
+      if workspace?
+        if options[:workspace] && options[:scheme]
+          build_settings(key: "PROJECT_FILE_PATH")
+        end
+      else
+        options[:project]
+      end
+    end
+
+  end
+end

--- a/xcov.gemspec
+++ b/xcov.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fastlane_core', '>= 0.44.0'
   spec.add_dependency 'slack-notifier', '~> 1.3'
+  spec.add_dependency 'xcodeproj', '~> 1.4'
   spec.add_dependency 'terminal-table' # print out build information
 
   # Development only


### PR DESCRIPTION
This adds a option which being set ignores the targets of auxiliary projects in a workspace.
For example, by setting `--only_project_targets`, xcov will ignore Pods targets.